### PR TITLE
Remove cases where lists of Wires are fed into Wires class

### DIFF
--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -16,11 +16,11 @@ This module contains the :class:`Device` abstract base class.
 """
 # pylint: disable=too-many-format-args
 import abc
+from collections.abc import Iterable
+from collections import OrderedDict
 
 import numpy as np
 
-from collections.abc import Iterable
-from collections import OrderedDict
 from pennylane.operation import (
     Operation,
     Observable,

--- a/pennylane/beta/devices/default_tensor.py
+++ b/pennylane/beta/devices/default_tensor.py
@@ -551,7 +551,7 @@ class DefaultTensor(Device):
                 tn.connect(obs_node[input_idx], ket[l])  # A|psi>
                 tn.connect(bra[l], obs_node[output_idx])  # <psi|A
 
-        meas_device_wires = Wires(meas_device_wires)
+        meas_device_wires = Wires.all_wires(meas_device_wires)
 
         # unmeasured wires are contracted directly between bra and ket
         unmeasured_device_wires = Wires.unique_wires([all_device_wires, meas_device_wires])

--- a/pennylane/circuit_drawer/grid.py
+++ b/pennylane/circuit_drawer/grid.py
@@ -46,7 +46,11 @@ class Grid:
         else:
             self.raw_grid = np.array(raw_grid, dtype=object)
             if len(self.raw_grid.shape) != 2:
-                raise ValueError("The entered raw grid was not parsed as two-dimensional array: {}".format(raw_grid))
+                raise ValueError(
+                    "The entered raw grid was not parsed as two-dimensional array: {}".format(
+                        raw_grid
+                    )
+                )
 
     def insert_layer(self, idx, layer):
         """Insert a layer into the Grid at the specified index.

--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -596,9 +596,7 @@ class CircuitGraph:
             temp_op_grid = OrderedDict()
             temp_obs_grid = OrderedDict()
 
-            permutation = [
-                self.wires.labels.index(i) for i in wire_order.labels if i in self.wires
-            ]
+            permutation = [self.wires.labels.index(i) for i in wire_order.labels if i in self.wires]
 
             for i, j in enumerate(permutation):
                 if j in operations:

--- a/pennylane/devices/default_qubit_autograd.py
+++ b/pennylane/devices/default_qubit_autograd.py
@@ -16,8 +16,8 @@ reference plugin.
 """
 from pennylane.operation import DiagonalOperation
 from pennylane import numpy as np
-from pennylane.wires import Wires
-import pennylane.numpy.tensor as Tensor
+from pennylane.wires import Wires, WireError
+from pennylane.numpy.tensor import tensor
 
 from pennylane.devices import DefaultQubit
 from pennylane.devices import autograd_ops
@@ -170,7 +170,7 @@ class DefaultQubitAutograd(DefaultQubit):
         Returns:
             Wires: wires with new labels
         """
-        wires = Wires([w.item() if isinstance(w, Tensor) else w for w in wires])
+        wires = Wires([w.item() if isinstance(w, tensor) else w for w in wires])
         try:
             mapped_wires = wires.map(self.wire_map)
         except WireError as e:

--- a/pennylane/devices/default_qubit_tf.py
+++ b/pennylane/devices/default_qubit_tf.py
@@ -18,8 +18,8 @@ import numpy as np
 import semantic_version
 
 from pennylane.operation import DiagonalOperation
-from pennylane.wires import Wires
-import pennylane.numpy.tensor as Tensor
+from pennylane.wires import Wires, WireError
+from pennylane.numpy.tensor import tensor
 
 try:
     import tensorflow as tf
@@ -221,7 +221,7 @@ class DefaultQubitTF(DefaultQubit):
         Returns:
             Wires: wires with new labels
         """
-        wires = Wires([w.item() if isinstance(w, Tensor) else w for w in wires])
+        wires = Wires([w.item() if isinstance(w, tensor) else w for w in wires])
         try:
             mapped_wires = wires.map(self.wire_map)
         except WireError as e:

--- a/pennylane/devices/tests/test_compare_default_qubit.py
+++ b/pennylane/devices/tests/test_compare_default_qubit.py
@@ -192,7 +192,9 @@ class TestComparison:
                     rnd_wires = np.random.choice(range(n_wires), size=gate.num_wires, replace=False)
                     gate(
                         *params,
-                        wires=[int(w) for w in rnd_wires]  # make sure we do not address wires as 0-d arrays
+                        wires=[
+                            int(w) for w in rnd_wires
+                        ]  # make sure we do not address wires as 0-d arrays
                     )
             return qml.expval(qml.PauliZ(0))
 

--- a/pennylane/devices/tests/test_compare_default_qubit.py
+++ b/pennylane/devices/tests/test_compare_default_qubit.py
@@ -189,9 +189,10 @@ class TestComparison:
             for gates in gates_per_layers:
                 for gate in gates:
                     params = list(np.pi * np.random.rand(gate.num_params))
+                    rnd_wires = np.random.choice(range(n_wires), size=gate.num_wires, replace=False)
                     gate(
                         *params,
-                        wires=np.random.choice(range(n_wires), size=gate.num_wires, replace=False)
+                        wires=[int(w) for w in rnd_wires]  # make sure we do not address wires as 0-d arrays
                     )
             return qml.expval(qml.PauliZ(0))
 

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -1246,7 +1246,7 @@ class Tensor(Observable):
         Returns:
             Wires: wires addressed by the observables in the tensor product
         """
-        return Wires([o.wires for o in self.obs])
+        return Wires.all_wires([o.wires for o in self.obs])
 
     @property
     def data(self):

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -46,12 +46,11 @@ def _process(wires):
         except TypeError as e:
             # Make sure it really was a hashability issue
             if str(e).startswith("unhashable"):
-                raise WireError("Wires must be hashable; got {}.".format(wires))
-            else:
-                raise WireError("Unknown issue with iterable wires input; got {}.".format(wires))
+                raise WireError("Wires must be hashable; got {}.".format(wires)) from e
+            raise WireError("Unknown issue with iterable wires input; got {}.".format(wires)) from e
 
         if len(set_of_wires) != len(tuple_of_wires):
-            raise WireError("Wires must be unique; got {}.".format(wires))
+            raise WireError("Wires must be unique; got {}.".format(wires)) from e
 
         return tuple_of_wires
 

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -25,6 +25,7 @@ class WireError(Exception):
 
 def _process(wires):
     """Converts the input to a tuple of numbers or strings."""
+
     if isinstance(wires, (Number, str)):
         # interpret as a single wire
         return (wires,)
@@ -38,12 +39,6 @@ def _process(wires):
         return (wires.item(),)
 
     if isinstance(wires, Iterable):
-        for wire in wires:
-            if isinstance(wire, Wires):
-                merged_wires_tuple = Wires.all_wires(wires).labels
-                if sum([len(w.labels) for w in wires]) != len(merged_wires_tuple):
-                    raise WireError("Wires must be unique; got {}.".format(wires))
-                return merged_wires_tuple
 
         tuple_of_wires = tuple(wires)
         try:  # We need the set for the uniqueness check, so we can use it for hashability check

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -50,7 +50,7 @@ def _process(wires):
             raise WireError("Unknown issue with iterable wires input; got {}.".format(wires)) from e
 
         if len(set_of_wires) != len(tuple_of_wires):
-            raise WireError("Wires must be unique; got {}.".format(wires)) from e
+            raise WireError("Wires must be unique; got {}.".format(wires))
 
         return tuple_of_wires
 

--- a/tests/test_wires.py
+++ b/tests/test_wires.py
@@ -48,20 +48,17 @@ class TestWires:
         wires = Wires(iterable)
         assert wires.labels == tuple(iterable)
 
-    @pytest.mark.parametrize("iterable", [Wires([0, 1, 2])])
-    def test_creation_from_wires_object(self, iterable):
+    def test_creation_from_wires_object(self):
         """Tests that a Wires object can be created from another Wires object."""
 
-        wires = Wires(iterable)
+        wires = Wires(Wires([0, 1, 2]))
         assert wires.labels == (0, 1, 2)
 
-    @pytest.mark.parametrize("iterable", [[Wires([0, 1]), Wires([2])],
-                                          [Wires([0]), Wires([1]), Wires([2])]])
-    def test_creation_from_wires_object(self, iterable):
+    def test_creation_from_wires_lists(self):
         """Tests that a Wires object can be created from a list of Wires."""
 
-        wires = Wires(iterable)
-        assert wires.labels == (0, 1, 2)
+        wires = Wires([Wires([0]), Wires([1]), Wires([2])])
+        assert wires.labels == (Wires([0]), Wires([1]), Wires([2]))
 
     @pytest.mark.parametrize("iterable", [[1, 0, 4],
                                           ['a', 'b', 'c'],
@@ -93,8 +90,7 @@ class TestWires:
     @pytest.mark.parametrize("iterable", [np.array([4, 1, 1, 3]),
                                           [4, 1, 1, 3],
                                           (4, 1, 1, 3),
-                                          ['a', 'a', 'b'],
-                                          [Wires([1, 0]), Wires([1, 2]), Wires([3])]])
+                                          ['a', 'a', 'b']])
     def test_error_for_repeated_wires(self, iterable):
         """Tests that a Wires object cannot be created from iterables with repeated indices."""
 
@@ -141,12 +137,8 @@ class TestWires:
         assert not Wires([0, 4]) in wires
         assert not Wires([4]) in wires
 
-        #assert [0, 3] in wires
-        #assert [1] in wires
         assert not [0, 4] in wires
         assert not [4] in wires
-
-        #assert (0, 3) in wires
 
     def test_add_two_wires_objects(self):
         """Tests that wires objects add correctly."""
@@ -250,7 +242,7 @@ class TestWires:
         assert wires.indices(1) == [2]
 
     @pytest.mark.parametrize("wires, wire_map, expected", [(Wires(['a', 'b']),
-                                                            {'a': Wires(0), 'b': Wires(1)},
+                                                            {'a': 0, 'b': 1},
                                                             Wires([0, 1])),
                                                            (Wires([-1, 1]),
                                                             {1: 'c', -1: 1, 'd': 'e'},
@@ -268,7 +260,7 @@ class TestWires:
         # error for non-unique wire labels
         with pytest.raises(WireError, match="Failed to implement wire map"):
             wires = Wires([0, 1])
-            wires.map({0: 'a', 1: Wires('a')})
+            wires.map({0: 'a', 1: 'a'})
 
     def test_select_random_method(self):
         """Tests the ``select_random()`` method."""


### PR DESCRIPTION
These relatively few changes allow us to remove some more lines of code in the `_process` function and make the logic more consistent (i.e. the elements of iterables are interpreted as wire labels).  